### PR TITLE
Making fluentd_elasticsearch_user/password mandatory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,6 @@ fluentd_sources: []
 
 fluentd_plugins: []
 fluentd_elasticsearch_host: "logs.data-{{ environment_tier }}.{{ domain }}"
+fluentd_elasticsearch_user: "{{ mandatory }}"
+fluentd_elasticsearch_password: "{{ mandatory }}"
 fluentd_influxdb_host: "metrics.data-{{ environment_tier }}.{{ domain }}"

--- a/templates/usr/local/etc/fluentd/plugins.d/plugins.conf.template
+++ b/templates/usr/local/etc/fluentd/plugins.d/plugins.conf.template
@@ -6,8 +6,8 @@
     host {{ fluentd_elasticsearch_host }}
     port 9200
     {% if environment_tier in ['production', 'staging'] %}
-    user {{ elasticsearch_user }}
-    password {{ elasticsearch_password }}
+    user {{ fluentd_elasticsearch_user }}
+    password {{ fluentd_elasticsearch_password }}
     {% endif %}
     index_name {{ project }}
     type_name nginx_access
@@ -21,8 +21,8 @@
     host {{ fluentd_elasticsearch_host }}
     port 9200
     {% if environment_tier in ['production', 'staging'] %}
-    user {{ elasticsearch_user }}
-    password {{ elasticsearch_password }}
+    user {{ fluentd_elasticsearch_user }}
+    password {{ fluentd_elasticsearch_password }}
     {% endif %}
     index_name {{ project }}
     type_name nginx_error
@@ -36,8 +36,8 @@
     host {{ fluentd_elasticsearch_host }}
     port 9200
     {% if environment_tier in ['production', 'staging'] %}
-    user {{ elasticsearch_user }}
-    password {{ elasticsearch_password }}
+    user {{ fluentd_elasticsearch_user }}
+    password {{ fluentd_elasticsearch_password }}
     {% endif %}
     index_name {{ project }}
     type_name php_error
@@ -51,8 +51,8 @@
     host {{ fluentd_elasticsearch_host }}
     port 9200
     {% if environment_tier in ['production', 'staging'] %}
-    user {{ elasticsearch_user }}
-    password {{ elasticsearch_password }}
+    user {{ fluentd_elasticsearch_user }}
+    password {{ fluentd_elasticsearch_password }}
     {% endif %}
     index_name {{ project }}
     type_name php_service


### PR DESCRIPTION
requires actually defining the variables in the defaults,
which requires namespacing the variable name with 'fluentd'
NOTE: all projects will need to change elasticsearch_user/password to
fluentd_elasticsearch_user/password in the vaults